### PR TITLE
Original

### DIFF
--- a/mod_dumpost.h
+++ b/mod_dumpost.h
@@ -22,7 +22,6 @@
 #define LOG_IS_FULL -1
 #define DEFAULT_MAX_SIZE 1024*1024
 #define min(a,b) (a)<(b)?(a):(b)
-#define DEBUG(s,t) ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, f->c->base_server, s, t);
 #define CREATEMODE ( APR_UREAD | APR_UWRITE | APR_GREAD )
 
 typedef struct dumpost_cfg_t {


### PR DESCRIPTION
Here are some corrections on buffer size.
I also rewrote most of the code in this branch https://github.com/zaccheob/mod_dumpost/tree/myversion simplifying some things and removing DumpPostLogFile option. I need to use this module in high traffic production site for logging purposes and I think that an open/write/close for each request will be a bottleneck. If you want to take a look...
